### PR TITLE
Add basic audio analysis GUI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# codexy_python_song_analyzer
+# Neon Song Analyzer
+
+Desktop audio analysis tool built with Python, PyQt5 and librosa.
+
+## Features
+- Drag and drop audio loading
+- Key distribution bar chart
+- Dominant melody notes list
+- Tempo estimation
+- Frequency band energy visualization
+- Dynamic range meter
+- Waveform display
+
+Run with:
+```
+python main.py
+```

--- a/audio_analyzer.py
+++ b/audio_analyzer.py
@@ -1,0 +1,86 @@
+import numpy as np
+import librosa
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+
+@dataclass
+class AnalysisResults:
+    duration: float
+    tempo: float
+    key_distribution: Dict[str, float]
+    top_notes: List[Tuple[str, int]]
+    band_energy: Dict[str, float]
+    dynamic_range: float
+    loudness_envelope: np.ndarray
+
+
+class AudioAnalyzer:
+    def __init__(self, file_path: str, sr: int = 22050):
+        self.file_path = file_path
+        self.sr = sr
+        self.y = None
+        self.duration = 0.0
+
+    def load(self):
+        self.y, _ = librosa.load(self.file_path, sr=self.sr)
+        self.duration = librosa.get_duration(y=self.y, sr=self.sr)
+
+    def analyze(self) -> AnalysisResults:
+        if self.y is None:
+            self.load()
+
+        y = self.y
+        sr = self.sr
+
+        # Tempo
+        tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
+
+        # Chroma / key distribution
+        chroma = librosa.feature.chroma_cqt(y=y, sr=sr)
+        chroma_mean = chroma.mean(axis=1)
+        note_names = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+        key_distribution = {
+            note: float(val / chroma_mean.sum()) for note, val in zip(note_names, chroma_mean)
+        }
+
+        # Pitch tracking using pyin
+        fmin = librosa.note_to_hz('C2')
+        fmax = librosa.note_to_hz('C7')
+        pitches, _ = librosa.pyin(y, fmin=fmin, fmax=fmax)
+        valid_pitches = pitches[~np.isnan(pitches)]
+        note_sequence = librosa.hz_to_note(valid_pitches)
+        counts = Counter(note_sequence)
+        top_notes = counts.most_common(10)
+
+        # Frequency band energy
+        S = np.abs(librosa.stft(y))
+        freqs = librosa.fft_frequencies(sr=sr)
+
+        def band_power(f_low, f_high):
+            idx = (freqs >= f_low) & (freqs < f_high)
+            return float(np.sum(S[idx, :] ** 2))
+
+        band_energy = {
+            'low': band_power(20, 250),
+            'mid': band_power(250, 4000),
+            'high': band_power(4000, sr / 2)
+        }
+
+        # Dynamic range
+        rms = librosa.feature.rms(y=y)[0]
+        dynamic_range = float(rms.max() - rms.min())
+
+        # Loudness envelope
+        loudness_envelope = rms
+
+        return AnalysisResults(
+            duration=self.duration,
+            tempo=float(tempo),
+            key_distribution=key_distribution,
+            top_notes=top_notes,
+            band_energy=band_energy,
+            dynamic_range=dynamic_range,
+            loudness_envelope=loudness_envelope,
+        )

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,126 @@
+import sys
+from PyQt5 import QtCore, QtGui, QtWidgets
+import pyqtgraph as pg
+import numpy as np
+from audio_analyzer import AudioAnalyzer
+
+ACCENT = 'rgb(100, 51, 162)'
+
+
+class DropLabel(QtWidgets.QLabel):
+    file_dropped = QtCore.pyqtSignal(str)
+
+    def __init__(self, text='Drop audio file here'):
+        super().__init__(text)
+        self.setAlignment(QtCore.Qt.AlignCenter)
+        self.setAcceptDrops(True)
+        self.setStyleSheet(f'border: 2px dashed {ACCENT}; padding: 40px;')
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        for url in event.mimeData().urls():
+            self.file_dropped.emit(url.toLocalFile())
+            break
+
+
+class MainWindow(QtWidgets.QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle('Neon Song Analyzer')
+        self.setStyleSheet(f'background-color: #111; color: {ACCENT};')
+        self.analyzer = None
+
+        self.drop_label = DropLabel()
+        self.drop_label.file_dropped.connect(self.load_file)
+
+        self.waveform_plot = pg.PlotWidget()
+        self.waveform_plot.setBackground('#111')
+        self.waveform_plot.getPlotItem().hideAxis('bottom')
+        self.waveform_plot.getPlotItem().hideAxis('left')
+
+        self.key_plot = pg.BarGraphItem(x=range(12), height=np.zeros(12), width=0.6, brush=ACCENT)
+        self.key_widget = pg.PlotWidget()
+        self.key_widget.setBackground('#111')
+        self.key_widget.addItem(self.key_plot)
+        self.key_widget.getPlotItem().getAxis('bottom').setTicks([
+            [(i, note) for i, note in enumerate(['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'])]
+        ])
+
+        self.bpm_label = QtWidgets.QLabel('BPM: -')
+        self.bpm_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.duration_label = QtWidgets.QLabel('Duration: -')
+        self.duration_label.setAlignment(QtCore.Qt.AlignCenter)
+
+        self.note_list = QtWidgets.QListWidget()
+        self.eq_plot = pg.PlotWidget()
+        self.eq_bar = pg.BarGraphItem(x=[0,1,2], height=[0,0,0], width=0.6, brush=ACCENT)
+        self.eq_plot.addItem(self.eq_bar)
+        self.eq_plot.getPlotItem().getAxis('bottom').setTicks([
+            [(0,'Low'),(1,'Mid'),(2,'High')]
+        ])
+
+        self.dynamic_meter = QtWidgets.QProgressBar()
+        self.dynamic_meter.setRange(0, 1000)
+
+        self.reset_btn = QtWidgets.QPushButton('Reset')
+        self.reset_btn.clicked.connect(self.reset)
+        self.reset_btn.setStyleSheet(f'background-color:{ACCENT}; color:#fff;')
+
+        layout = QtWidgets.QGridLayout(self)
+        layout.addWidget(self.drop_label, 0, 0, 1, 2)
+        layout.addWidget(self.waveform_plot, 1, 0, 1, 2)
+        layout.addWidget(self.key_widget, 2, 0)
+        layout.addWidget(self.note_list, 2, 1)
+        layout.addWidget(self.eq_plot, 3, 0)
+        layout.addWidget(self.dynamic_meter, 3, 1)
+        layout.addWidget(self.bpm_label, 4, 0)
+        layout.addWidget(self.duration_label, 4, 1)
+        layout.addWidget(self.reset_btn, 5, 0, 1, 2)
+
+    def load_file(self, path):
+        self.analyzer = AudioAnalyzer(path)
+        results = self.analyzer.analyze()
+        self.update_ui(results)
+
+    def update_ui(self, res):
+        x = np.linspace(0, res.duration, num=len(self.analyzer.y))
+        self.waveform_plot.plot(x, self.analyzer.y, pen=ACCENT, clear=True)
+
+        heights = [res.key_distribution[note] for note in ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B']]
+        self.key_plot.setOpts(height=heights)
+
+        self.bpm_label.setText(f'BPM: {res.tempo:.1f}')
+        self.duration_label.setText(f'Duration: {res.duration:.2f}s')
+
+        self.note_list.clear()
+        for note, count in res.top_notes:
+            self.note_list.addItem(f'{note}: {count}')
+
+        self.eq_bar.setOpts(height=[res.band_energy['low'], res.band_energy['mid'], res.band_energy['high']])
+
+        self.dynamic_meter.setValue(int(res.dynamic_range * 1000))
+
+    def reset(self):
+        self.waveform_plot.clear()
+        self.key_plot.setOpts(height=np.zeros(12))
+        self.bpm_label.setText('BPM: -')
+        self.duration_label.setText('Duration: -')
+        self.note_list.clear()
+        self.eq_bar.setOpts(height=[0,0,0])
+        self.dynamic_meter.setValue(0)
+        self.analyzer = None
+
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    win = MainWindow()
+    win.resize(800, 600)
+    win.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from gui import main
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+librosa
+numpy
+soundfile
+PyQt5
+pyqtgraph


### PR DESCRIPTION
## Summary
- implement `AudioAnalyzer` with tempo, pitch, key, energy and loudness metrics
- create PyQt-based GUI to display waveform, key distribution, BPM and more
- document project setup and dependencies

## Testing
- `python -m py_compile audio_analyzer.py gui.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688bb37f16ac832387da73cc28e8fa81