### PR TITLE
Add browse button for audio file selection

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -36,6 +36,10 @@ class MainWindow(QtWidgets.QWidget):
         self.drop_label = DropLabel()
         self.drop_label.file_dropped.connect(self.load_file)
 
+        self.browse_btn = QtWidgets.QPushButton('Browse')
+        self.browse_btn.clicked.connect(self.browse_file)
+        self.browse_btn.setStyleSheet(f'background-color:{ACCENT}; color:#fff;')
+
         self.waveform_plot = pg.PlotWidget()
         self.waveform_plot.setBackground('#111')
         self.waveform_plot.getPlotItem().hideAxis('bottom')
@@ -70,7 +74,8 @@ class MainWindow(QtWidgets.QWidget):
         self.reset_btn.setStyleSheet(f'background-color:{ACCENT}; color:#fff;')
 
         layout = QtWidgets.QGridLayout(self)
-        layout.addWidget(self.drop_label, 0, 0, 1, 2)
+        layout.addWidget(self.drop_label, 0, 0)
+        layout.addWidget(self.browse_btn, 0, 1)
         layout.addWidget(self.waveform_plot, 1, 0, 1, 2)
         layout.addWidget(self.key_widget, 2, 0)
         layout.addWidget(self.note_list, 2, 1)
@@ -79,6 +84,11 @@ class MainWindow(QtWidgets.QWidget):
         layout.addWidget(self.bpm_label, 4, 0)
         layout.addWidget(self.duration_label, 4, 1)
         layout.addWidget(self.reset_btn, 5, 0, 1, 2)
+
+    def browse_file(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, 'Open Audio File')
+        if path:
+            self.load_file(path)
 
     def load_file(self, path):
         self.analyzer = AudioAnalyzer(path)


### PR DESCRIPTION
## Summary
- add a browse button to open audio files from a dialog
- hook the browse button into the existing loader and layout

## Testing
- `python -m py_compile gui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688bbba439d48323bf09e76ac6503868