### PR TITLE
Refine GUI file loading

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -67,10 +67,6 @@ class MainWindow(QtWidgets.QWidget):
         drop_layout.addWidget(self.drop_label)
         drop_layout.addWidget(self.browse_btn)
 
-
-        self.browse_btn.clicked.connect(self.browse_file)
-        self.browse_btn.setStyleSheet(f'background-color:{ACCENT}; color:#fff;')
-
         self.waveform_plot = pg.PlotWidget()
         self.waveform_plot.setBackground('#111')
         self.waveform_plot.getPlotItem().hideAxis('bottom')
@@ -106,8 +102,6 @@ class MainWindow(QtWidgets.QWidget):
 
         layout = QtWidgets.QGridLayout(self)
         layout.addWidget(drop_container, 0, 0, 1, 2)
-        layout.addWidget(self.drop_label, 0, 0)
-        layout.addWidget(self.browse_btn, 0, 1)
         layout.addWidget(self.waveform_plot, 1, 0, 1, 2)
         layout.addWidget(self.key_widget, 2, 0)
         layout.addWidget(self.note_list, 2, 1)
@@ -116,11 +110,6 @@ class MainWindow(QtWidgets.QWidget):
         layout.addWidget(self.bpm_label, 4, 0)
         layout.addWidget(self.duration_label, 4, 1)
         layout.addWidget(self.reset_btn, 5, 0, 1, 2)
-
-    def browse_file(self):
-        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, 'Open Audio File')
-        if path:
-            self.load_file(path)
 
     def load_file(self, path):
         if self._thread is not None:
@@ -151,9 +140,7 @@ class MainWindow(QtWidgets.QWidget):
 
     def on_analysis_finished(self, analyzer, results):
         self.analyzer = analyzer
-        self.drop_label.setText(os.path.basename(path))
-        self.analyzer = AudioAnalyzer(path)
-        results = self.analyzer.analyze()
+        self.drop_label.setText(os.path.basename(analyzer.file_path))
         self.update_ui(results)
         if self._loader:
             self._loader.close()


### PR DESCRIPTION
## Summary
- Simplify drop area layout and remove redundant Browse handler
- Display analyzed file name and update UI using results from background thread

## Testing
- `python -m py_compile gui.py audio_analyzer.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_688bbd58830483238397c00d1898baa8