### PR TITLE
Add shortcuts and accessibility metadata

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -63,10 +63,19 @@ class MainWindow(QtWidgets.QWidget):
 
         self.drop_label = DropLabel()
         self.drop_label.setToolTip("Drag a song here or click Browse to analyze.")
+        self.drop_label.setAccessibleName("File Drop Area")
+        self.drop_label.setAccessibleDescription(
+            "Drop an audio file here to analyze it."
+        )
         self.drop_label.file_dropped.connect(self.load_file)
 
         self.browse_btn = QtWidgets.QPushButton('Browse')
         self.browse_btn.setToolTip("Select an audio file from disk.")
+        self.browse_btn.setAccessibleName("Browse Button")
+        self.browse_btn.setAccessibleDescription(
+            "Open a file dialog to select an audio file for analysis."
+        )
+        self.browse_btn.setShortcut('Ctrl+O')
         self.browse_btn.clicked.connect(self.open_file_dialog)
         self.browse_btn.setStyleSheet(
             f'background:{GRADIENT}; color:#fff; border:1px solid {ACCENT};'
@@ -80,6 +89,10 @@ class MainWindow(QtWidgets.QWidget):
 
         self.waveform_plot = pg.PlotWidget()
         self.waveform_plot.setToolTip("Waveform of the audio over time.")
+        self.waveform_plot.setAccessibleName("Waveform Plot")
+        self.waveform_plot.setAccessibleDescription(
+            "Displays the waveform of the loaded audio file over time."
+        )
         self.waveform_plot.setBackground(BACKGROUND)
         self.waveform_plot.setTitle("Waveform")
         self.waveform_plot.getPlotItem().setLabel('bottom', 'Time (s)')
@@ -88,6 +101,10 @@ class MainWindow(QtWidgets.QWidget):
         self.key_plot = pg.BarGraphItem(x=range(12), height=np.zeros(12), width=0.6, brush=GRADIENT_BRUSH)
         self.key_widget = pg.PlotWidget()
         self.key_widget.setToolTip("Distribution of detected musical keys.")
+        self.key_widget.setAccessibleName("Key Distribution Plot")
+        self.key_widget.setAccessibleDescription(
+            "Shows the distribution of detected musical keys in the song."
+        )
         self.key_widget.setBackground(BACKGROUND)
         self.key_widget.setTitle("Key Distribution")
         self.key_widget.addItem(self.key_plot)
@@ -104,9 +121,17 @@ class MainWindow(QtWidgets.QWidget):
 
         self.note_list = QtWidgets.QListWidget()
         self.note_list.setToolTip("Most frequent melody notes.")
+        self.note_list.setAccessibleName("Top Notes List")
+        self.note_list.setAccessibleDescription(
+            "Lists the most frequent melody notes detected in the song."
+        )
         self.note_list.setStyleSheet(f'background:{BACKGROUND}; color:#fff;')
         self.eq_plot = pg.PlotWidget()
         self.eq_plot.setToolTip("Energy in low, mid, and high frequency bands.")
+        self.eq_plot.setAccessibleName("Frequency Spectrum Plot")
+        self.eq_plot.setAccessibleDescription(
+            "Shows the energy levels for low, mid, and high frequency bands."
+        )
         self.eq_plot.setBackground(BACKGROUND)
         self.eq_plot.setTitle("Frequency Spectrum")
         self.eq_bar = pg.BarGraphItem(x=[0,1,2], height=[0,0,0], width=0.6, brush=GRADIENT_BRUSH)
@@ -119,6 +144,10 @@ class MainWindow(QtWidgets.QWidget):
 
         self.dynamic_meter = QtWidgets.QProgressBar()
         self.dynamic_meter.setToolTip("Dynamic range (0–1000 scale).")
+        self.dynamic_meter.setAccessibleName("Dynamic Range Meter")
+        self.dynamic_meter.setAccessibleDescription(
+            "Indicates the song's dynamic range on a scale from 0 to 1000."
+        )
         self.dynamic_meter.setRange(0, 1000)
         self.dynamic_meter.setStyleSheet(
             f"QProgressBar {{background-color: {BACKGROUND}; color: #fff; border: 1px solid {ACCENT};}}"
@@ -127,6 +156,11 @@ class MainWindow(QtWidgets.QWidget):
 
         self.reset_btn = QtWidgets.QPushButton('Reset')
         self.reset_btn.setToolTip("Clear analysis results.")
+        self.reset_btn.setAccessibleName("Reset Button")
+        self.reset_btn.setAccessibleDescription(
+            "Clears analysis results and resets the interface."
+        )
+        self.reset_btn.setShortcut('Ctrl+R')
         self.reset_btn.clicked.connect(self.reset)
         self.reset_btn.setStyleSheet(
             f'background:{GRADIENT}; color:#fff; border:1px solid {ACCENT};'


### PR DESCRIPTION
## Summary
- Assign Ctrl+O and Ctrl+R shortcuts to browse and reset actions
- Add accessible names and descriptions to key UI controls for screen readers

## Testing
- `python -m py_compile gui.py audio_analyzer.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688bc43ce6888323919f08dbc73de4ee