### PR TITLE
Add pulsing purple theme and dynamic range plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Desktop audio analysis tool built with Python, PyQt5 and librosa.
 - Dominant melody notes list
 - Tempo estimation
 - Frequency band energy visualization
-- Dynamic range meter
+- Dynamic range plot (dB)
 - Waveform display
 
 Run with:

--- a/audio_analyzer.py
+++ b/audio_analyzer.py
@@ -70,12 +70,13 @@ class AudioAnalyzer:
             'high': band_power(4000, sr / 2)
         }
 
-        # Dynamic range
+        # Dynamic range in decibels
         rms = librosa.feature.rms(y=y)[0]
-        dynamic_range = float(rms.max() - rms.min())
+        rms_min = rms[rms > 0].min() if np.any(rms > 0) else 1e-10
+        dynamic_range = float(20 * np.log10(rms.max() / rms_min))
 
-        # Loudness envelope
-        loudness_envelope = rms
+        # Loudness envelope in decibels
+        loudness_envelope = librosa.amplitude_to_db(rms, ref=np.max)
 
         return AnalysisResults(
             duration=self.duration,


### PR DESCRIPTION
## Summary
- Restyle interface with pulsing purple neon accent and dark red secondary background
- Replace dynamic range meter with waveform-based dB plot and label
- Compute dynamic range in decibels in the analyzer

## Testing
- `python -m py_compile audio_analyzer.py gui.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688bd39af5388323865468d3b685d86c