### PR TITLE
Add note time highlighting in waveform

### DIFF
--- a/audio_analyzer.py
+++ b/audio_analyzer.py
@@ -14,6 +14,7 @@ class AnalysisResults:
     band_energy: Dict[str, float]
     dynamic_range: float
     loudness_envelope: np.ndarray
+    note_times: Dict[str, List[float]] = field(default_factory=dict)
 
 
 class AudioAnalyzer:
@@ -51,10 +52,14 @@ class AudioAnalyzer:
         # `librosa.pyin` now returns three values: pitches, voiced_flags, and voiced_probabilities
         # We only need the pitches here, so capture the additional outputs with underscores
         pitches, _, _ = librosa.pyin(y, fmin=fmin, fmax=fmax)
-        valid_pitches = pitches[~np.isnan(pitches)]
-        note_sequence = librosa.hz_to_note(valid_pitches)
-        counts = Counter(note_sequence)
-        top_notes = counts.most_common(10)
+        times = librosa.times_like(pitches, sr=sr)
+        note_times: Dict[str, List[float]] = {}
+        for pitch, t in zip(pitches, times):
+            if np.isnan(pitch):
+                continue
+            note = librosa.hz_to_note(pitch)
+            note_times.setdefault(note, []).append(float(t))
+        top_notes = Counter({n: len(ts) for n, ts in note_times.items()}).most_common(10)
 
         # Frequency band energy
         S = np.abs(librosa.stft(y))
@@ -86,4 +91,5 @@ class AudioAnalyzer:
             band_energy=band_energy,
             dynamic_range=dynamic_range,
             loudness_envelope=loudness_envelope,
+            note_times=note_times,
         )


### PR DESCRIPTION
## Summary
- collect timing information for each detected note during analysis
- allow GUI note clicks to display timestamp markers on the waveform
- clear and reset note markers on new selections or when resetting the UI

## Testing
- `python -m py_compile audio_analyzer.py gui.py`


------
https://chatgpt.com/codex/tasks/task_e_688bda14491c8323b3e218979443ad7f