### PR TITLE
Animate waveform using BPM-synced marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ Desktop audio analysis tool built with Python, PyQt5 and librosa.
 - Drag and drop audio loading
 - Key distribution bar chart
 - Dominant melody notes list
-- Highlight selected note positions in waveform
 - Tempo estimation
 - Frequency band energy visualization
 - Dynamic range plot (dB)
-- Waveform display
+- Waveform display with BPM-synced marker
 
 Run with:
 ```


### PR DESCRIPTION
## Summary
- add BPM-synced marker animation to waveform using a moving vertical line
- manage beat animation lifecycle on analysis and reset
- document new tempo-driven waveform marker

## Testing
- `python -m py_compile audio_analyzer.py gui.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688be4ac55b88323ab258f89d5c54d83